### PR TITLE
DataLayer - added {_clear: true} for the push call as default

### DIFF
--- a/src/utilities/__tests__/dataLayer.test.ts
+++ b/src/utilities/__tests__/dataLayer.test.ts
@@ -24,6 +24,7 @@ describe('dataLayer', () => {
                 const firstItem = window.dataLayer[0];
 
                 expect(firstItem).toEqual({
+                    _clear: true,
                     event: 'preorder',
                     action: 'submit',
                     context: {
@@ -60,6 +61,7 @@ describe('dataLayer', () => {
                 expect(addedItem).toEqual({
                     event: 'preorder',
                     action: 'submit',
+                    _clear: true,
                 });
             });
         });

--- a/src/utilities/dataLayer.ts
+++ b/src/utilities/dataLayer.ts
@@ -4,12 +4,14 @@ import { Serializable } from '../types/utility';
  * @param {String} event            i.e. preorder
  * @param {String} action           i.e. submit
  * @param {Serializable=} context   i.e. { subscribeToNewsletter: true }
+ * @param {Boolean} clear           i.e. false
  */
 export function pushTrackingEvent(
     event: string,
     action: string,
-    context?: Serializable
+    context?: Serializable,
+    clear?: boolean
 ): void {
     window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push({ event, action, context });
+    window.dataLayer.push({ event, action, context, _clear: clear ?? true });
 }


### PR DESCRIPTION
Zoals besproken in de laatste vakgroep meeting [doc](https://docs.google.com/document/d/1Ftabucy10os_rb34npa7gEPnNkOPvpDXS77nwGAxsv4/edit), heb ik bij de datalayer.push event `_clear:true ` als default eraan toegevoegd.

We liepen namelijk er weer tegen aan bij de Centraal Beheer project 