### PR TITLE
fix build by generating es2018 instead of pure-esm module

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
+// babel is only used for the jest tests, not for the library build
 module.exports = {
     presets: [
         [

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
         "url": "https://freshheads.com",
         "email": "info@freshheads.com"
     },
+    "engines": {
+        "node": ">=14"
+    },
     "keywords": [
         "freshheads",
         "javascript utilities"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,66 +1,22 @@
 {
     "compilerOptions": {
-        /* Basic Options */
-        // "incremental": true,                   /* Enable incremental compilation */
-        "target": "ESNext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-        "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-        // "lib": [],                             /* Specify library files to be included in the compilation. */
-        // "allowJs": true,                       /* Allow javascript files to be compiled. */
-        // "checkJs": true,                       /* Report errors in .js files. */
+        "target": "ES2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+        "lib": ["dom", "esnext"],
         "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
-        "declaration": true /* Genera  corresponding '.d.ts' file. */,
-        // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-        // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+        "declaration": true /* Generate corresponding '.d.ts' file. */,
+        "sourceMap": true,
         // "outFile": "./",                       /* Concatenate and emit output to single file. */
         "outDir": "./build" /* Redirect output structure to the directory. */,
         "rootDir": "src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
-        // "composite": true,                     /* Enable project compilation */
-        // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
         // "removeComments": true,                /* Do not emit comments to output. */
         // "noEmit": true,                        /* Do not emit outputs. */
-        // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-        // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-        // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-        /* Strict Type-Checking Options */
         "strict": true /* Enable all strict type-checking options. */,
-        // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-        // "strictNullChecks": true,              /* Enable strict null checks. */
-        // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-        // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-        // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-        // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-        // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-        /* Additional Checks */
         "noUnusedLocals": true /* Report errors on unused locals. */,
         "noUnusedParameters": true /* Report errors on unused parameters. */,
         "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
         "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
-
-        /* Module Resolution Options */
         "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-        // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-        // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-        // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-        // "typeRoots": [],                       /* List of folders to include type definitions from. */
-        // "types": [],                           /* Type declaration files to be included in compilation. */
-        // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
         "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-        // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-        // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
-        /* Source Map Options */
-        // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-        // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-        // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-        // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-        /* Experimental Options */
-        // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-        // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-
-        /* Advanced Options */
         "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
     },
     "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"],


### PR DESCRIPTION
Fixes #30 

Heb nog geprobeerd om met RollUp een aparte esm / common js build te maken maar dan moet je volgens mij perse met een single entry file werken. Wat nu een breaking change zou betekenen. Daarnaast ging hierdoor ook tree shaking kapot.

Dit lijkt voor nu de eenvoudigste fix en levert eigenlijk geen verschil in output op omdat ES2018 alle syntax al ondersteund die we tot nu toe gebruikt hebben.
Het probleem is eigenlijk dan wanneer je een ESNEXT module maakt kijkt naar de laatste standaard want nu een pure-esm module is. En die vereist vervolgens wanneer je hem via node importeert dat de package.json ook een `module: true` setting heeft. Wat prima is maar blijkbaar kan webpack daar weer niet mee omgaan. 
Het wordt als snel vrij ingewikkeld en de documentatie / meningen rondom dit onderwerp gaan ook alle kanten uit.

Ik heb me voor nu vooral laten leiden door het idee om niet onzinnig een bundler zoals roll up of webpack er tussen te hangen. https://cmdcolin.github.io/posts/2022-05-27-youmaynotneedabundler